### PR TITLE
chore(maintenance): upgrade dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,11 @@
       "name": "blueprint-playground",
       "version": "1.0.0",
       "dependencies": {
-        "@blueprintjs/core": "^5.1.3",
-        "@blueprintjs/datetime": "^5.0.5",
-        "@blueprintjs/icons": "^5.1.2",
-        "@blueprintjs/select": "^5.0.5",
-        "@blueprintjs/table": "^5.0.5",
+        "@blueprintjs/core": "^5.1.5",
+        "@blueprintjs/datetime": "^5.0.7",
+        "@blueprintjs/icons": "^5.1.4",
+        "@blueprintjs/select": "^5.0.7",
+        "@blueprintjs/table": "^5.0.7",
         "@codux-boards/react-blueprint": "^1.0.13",
         "classnames": "^2.3.2",
         "react": "^17.0.2",
@@ -23,11 +23,11 @@
         "@types/react": "^17.0.52",
         "@types/react-dom": "^17.0.18",
         "@vitejs/plugin-react": "^4.0.3",
-        "@wixc3/react-board": "^2.2.1",
+        "@wixc3/react-board": "^2.3.0",
         "prettier": "^3.0.0",
-        "sass": "^1.63.6",
+        "sass": "^1.64.1",
         "typescript": "~5.1.6",
-        "vite": "^4.4.4"
+        "vite": "^4.4.7"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -370,12 +370,12 @@
       }
     },
     "node_modules/@blueprintjs/core": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-5.1.3.tgz",
-      "integrity": "sha512-RCJgFJGieZgHKu3uUxa4klDx+mCxzibYL0YxmZ9NFRd3vwK9Bsanmr/Fz04Q7OM4olK76qebNjtvjRHVsUv3DA==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-5.1.5.tgz",
+      "integrity": "sha512-eyPTQZUVFE1ZO/4g+JWAybbdTvZu8isZh7MFxBegrMvXvhS8i8qNv0lnEwYcWTkNkBOiVRhnE1fn1LVNUoFL/g==",
       "dependencies": {
         "@blueprintjs/colors": "^5.0.1",
-        "@blueprintjs/icons": "^5.1.2",
+        "@blueprintjs/icons": "^5.1.4",
         "@popperjs/core": "^2.11.7",
         "classnames": "^2.3.1",
         "normalize.css": "^8.0.1",
@@ -399,13 +399,13 @@
       }
     },
     "node_modules/@blueprintjs/datetime": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/datetime/-/datetime-5.0.5.tgz",
-      "integrity": "sha512-yaHmvrglRkuKnEGlu2ZQ9oDAnGNoEiTIWYVwsc/cJmyo5bEeAZGOPAVpuJWUscjJNc8TzZJfOtN1n+aUcCCBQQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/datetime/-/datetime-5.0.7.tgz",
+      "integrity": "sha512-6FhAf5SR10L6keu3sPEmcXBvBDoYIKdlLeObUla7mnps2y23bs8rMmIDIm7UxYBTN5ULJiYWwFhwse0PCTMW9w==",
       "dependencies": {
-        "@blueprintjs/core": "^5.1.3",
-        "@blueprintjs/icons": "^5.1.2",
-        "@blueprintjs/select": "^5.0.5",
+        "@blueprintjs/core": "^5.1.5",
+        "@blueprintjs/icons": "^5.1.4",
+        "@blueprintjs/select": "^5.0.7",
         "classnames": "^2.3.1",
         "date-fns": "^2.28.0",
         "date-fns-tz": "^1.3.7",
@@ -425,9 +425,9 @@
       }
     },
     "node_modules/@blueprintjs/icons": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-5.1.2.tgz",
-      "integrity": "sha512-lPvEBRw8/l5Wiy9SUh1BPs1NUG1CAzanH9eRIi47q+qeNhZbdxn0ADIJkSerIwyZTJQnKubOFvy3WlJMMzfGYA==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-5.1.4.tgz",
+      "integrity": "sha512-2Vb8kneLZkKkH0VAkFbWHUixvI1UgFeDolev/TnyKHIaAPdGSmhoktmYsZNtcPiznZRrpb2PE03lU8fmBTi2KA==",
       "dependencies": {
         "change-case": "^4.1.2",
         "classnames": "^2.3.1",
@@ -445,12 +445,12 @@
       }
     },
     "node_modules/@blueprintjs/select": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/select/-/select-5.0.5.tgz",
-      "integrity": "sha512-8SmDCGrMRI7omhSKMeJ2GnIDmsItozbh11+D+O4NBLB2PnmflkrXu6QXYnO1pcsPDEolOR5OJiqKn/E+2fBXGA==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/select/-/select-5.0.7.tgz",
+      "integrity": "sha512-E1BhFjgzq7dXN2rK2Q0hw/zgdNe+EgzFdkOs2nriNr8cxenxK/nSOB4+lTCx3HTyueNSAIqxJv+Q6OPcw0bTYA==",
       "dependencies": {
-        "@blueprintjs/core": "^5.1.3",
-        "@blueprintjs/icons": "^5.1.2",
+        "@blueprintjs/core": "^5.1.5",
+        "@blueprintjs/icons": "^5.1.4",
         "classnames": "^2.3.1",
         "tslib": "~2.5.0"
       },
@@ -466,11 +466,11 @@
       }
     },
     "node_modules/@blueprintjs/table": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/table/-/table-5.0.5.tgz",
-      "integrity": "sha512-xOehSOk4gq6K6wVwldGfiK6NXRYpBaWcxCQ99EQ+El2ivMioxl3wit3QPlD42uaAG7Bgfgu856SzYbO9Tk0CZA==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/table/-/table-5.0.7.tgz",
+      "integrity": "sha512-QFNP68pIzserFRooKPMJkdqLaWMiPJlAkRyOiv8mbDhgP7EeIr8nvhX6TJkL7nmd9DMv+OD0xdoj/fuJ7KtYyQ==",
       "dependencies": {
-        "@blueprintjs/core": "^5.1.3",
+        "@blueprintjs/core": "^5.1.5",
         "classnames": "^2.3.1",
         "react-innertext": "^1.1.5",
         "tslib": "~2.5.0"
@@ -498,6 +498,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -513,6 +514,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -528,6 +530,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -543,6 +546,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -558,6 +562,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -573,6 +578,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -588,6 +594,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -603,6 +610,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -618,6 +626,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -633,6 +642,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -648,6 +658,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -663,6 +674,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -678,6 +690,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -693,6 +706,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -708,6 +722,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -723,6 +738,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -738,6 +754,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -753,6 +770,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -768,6 +786,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -783,6 +802,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -798,6 +818,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -813,6 +834,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1104,12 +1126,14 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "17.0.62",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.62.tgz",
       "integrity": "sha512-eANCyz9DG8p/Vdhr0ZKST8JV12PhH2ACCDYlFw6DIO+D+ca+uP4jtEDEpVqXZrh/uZdXQGwk7whJa3ah5DtyLw==",
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -1128,7 +1152,8 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
-      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
+      "dev": true
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.0.3",
@@ -1149,18 +1174,18 @@
       }
     },
     "node_modules/@wixc3/board-core": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@wixc3/board-core/-/board-core-2.2.1.tgz",
-      "integrity": "sha512-qgH27C0//bWq17FqdbudTTqBjd4Q7obuenC7fqtw/sEa6B39N9j6HzXeMPzEte3+W1v4dZnSGaPRn/BV/E0SYA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@wixc3/board-core/-/board-core-2.3.0.tgz",
+      "integrity": "sha512-uhq7hB72bfCK3yYb/+PRL8fEjoQxXQ1UjKhSY+Tr8UNo0lnRMw9EZ752ap9EGRKoldDumjbyrvFz4gjFsBgfJw==",
       "dev": true
     },
     "node_modules/@wixc3/react-board": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@wixc3/react-board/-/react-board-2.2.1.tgz",
-      "integrity": "sha512-oIY/FTb3DrNALg2Zof8KqUAQaB9VTP/86DSWE72SPAye2Xvbaib6gcir1+ni+fmR/W2IAGN9e5iSx+qc0QJMIw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@wixc3/react-board/-/react-board-2.3.0.tgz",
+      "integrity": "sha512-mEzTpHnFvvGrGNAifS1dMwuee/vlsnMbpJTkpggJX+XMyFCyVzm8BUw0wmh+RHkrcZjywrBYHP6AM6Iq6Aixdw==",
       "dev": true,
       "dependencies": {
-        "@wixc3/board-core": "^2.2.1"
+        "@wixc3/board-core": "^2.3.0"
       },
       "peerDependencies": {
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
@@ -1182,7 +1207,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -1200,7 +1225,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1209,7 +1234,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "fill-range": "^7.0.1"
       },
@@ -1341,7 +1366,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1504,6 +1529,7 @@
       "version": "0.18.13",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.13.tgz",
       "integrity": "sha512-vhg/WR/Oiu4oUIkVhmfcc23G6/zWuEQKFS+yiosSHe4aN6+DQRXIfeloYGibIfVhkr4wyfuVsGNLr+sQU1rWWw==",
+      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -1561,7 +1587,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -1573,6 +1599,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -1594,7 +1621,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -1631,7 +1658,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.1.tgz",
       "integrity": "sha512-lj9cnmB/kVS0QHsJnYKD1uo3o39nrbKxszjnqS9Fr6NB7bZzW45U6WSGBPKXDL/CvDKqDNPA4r3DoDQ8GTxo2A==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -1657,7 +1684,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -1669,7 +1696,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1678,7 +1705,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -1690,7 +1717,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -1784,6 +1811,7 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
       "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1815,7 +1843,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1916,6 +1944,7 @@
       "version": "8.4.26",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.26.tgz",
       "integrity": "sha512-jrXHFF8iTloAenySjM/ob3gSj7pCu0Ji49hnjqzsgSRa50hkWCKD0HQ+gMNJkW38jBI68MpAAg7ZWwHwX8NMMw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2061,7 +2090,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -2086,6 +2115,7 @@
       "version": "3.26.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.26.2.tgz",
       "integrity": "sha512-6umBIGVz93er97pMgQO08LuH3m6PUb3jlDUUGFsNJB6VgTCUaDFpupf5JfU30529m/UKOgmiX+uY6Sx8cOYpLA==",
+      "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -2098,10 +2128,10 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.63.6",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.63.6.tgz",
-      "integrity": "sha512-MJuxGMHzaOW7ipp+1KdELtqKbfAWbH7OLIdoSMnVe3EXPMTmxTmlaZDCTsgIpPCs3w99lLo9/zDKkOrJuT5byw==",
-      "devOptional": true,
+      "version": "1.64.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.64.1.tgz",
+      "integrity": "sha512-16rRACSOFEE8VN7SCgBu1MpYCyN7urj9At898tyzdXFhC+a+yOX5dXwAR7L8/IdPJ1NB8OYoXmD55DM30B2kEQ==",
+      "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -2154,6 +2184,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2186,7 +2217,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -2258,12 +2289,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.4.tgz",
-      "integrity": "sha512-4mvsTxjkveWrKDJI70QmelfVqTm+ihFAb6+xf4sjEU2TmUCTlVX87tmg/QooPEMQb/lM9qGHT99ebqPziEd3wg==",
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.7.tgz",
+      "integrity": "sha512-6pYf9QJ1mHylfVh39HpuSfMPojPSKVxZvnclX1K1FyZ1PXDOcLBibdq5t1qxJSnL63ca8Wf4zts6mD8u8oc9Fw==",
+      "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
-        "postcss": "^8.4.25",
+        "postcss": "^8.4.26",
         "rollup": "^3.25.2"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@blueprintjs/core": "^5.1.3",
-    "@blueprintjs/datetime": "^5.0.5",
-    "@blueprintjs/icons": "^5.1.2",
-    "@blueprintjs/select": "^5.0.5",
-    "@blueprintjs/table": "^5.0.5",
+    "@blueprintjs/core": "^5.1.5",
+    "@blueprintjs/datetime": "^5.0.7",
+    "@blueprintjs/icons": "^5.1.4",
+    "@blueprintjs/select": "^5.0.7",
+    "@blueprintjs/table": "^5.0.7",
     "@codux-boards/react-blueprint": "^1.0.13",
     "classnames": "^2.3.2",
     "react": "^17.0.2",
@@ -24,10 +24,10 @@
     "@types/react": "^17.0.52",
     "@types/react-dom": "^17.0.18",
     "@vitejs/plugin-react": "^4.0.3",
-    "@wixc3/react-board": "^2.2.1",
+    "@wixc3/react-board": "^2.3.0",
     "prettier": "^3.0.0",
-    "sass": "^1.63.6",
+    "sass": "^1.64.1",
     "typescript": "~5.1.6",
-    "vite": "^4.4.4"
+    "vite": "^4.4.7"
   }
 }


### PR DESCRIPTION
Keep react 17 because Blueprint uses 16 || 17 
https://www.npmjs.com/package/@blueprintjs/datetime?activeTab=code

![image](https://github.com/codux-demos/blueprint-playground/assets/89574610/1aeb6307-8fbe-4a37-8d31-c104203b63ee)

